### PR TITLE
removed strict mode

### DIFF
--- a/resources/js/randorande.jsx
+++ b/resources/js/randorande.jsx
@@ -3,11 +3,7 @@ import { createRoot } from "react-dom/client";
 import App from "./randorande/App";
 
 export default function RandoRandeApp() {
-    return (
-        <React.StrictMode>
-            <App />
-        </React.StrictMode>
-    );
+    return <App />;
 }
 
 const container = document.getElementById("randorande-app");


### PR DESCRIPTION
Strict Mode causes components to rerender which messes with the functionality. This is because the Strict mode refereshes the page in order to find bugs. It is not needed nor is it needed for deployment.